### PR TITLE
bos uses Fmt.Dump.signal, only available since fmt.0.8.0

### DIFF
--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ depends: [
   "rresult" {>= "0.4.0"}
   "astring"
   "fpath"
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "logs"
   "mtime" {test}
 ]


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/10713 for the upstream counterpart