### PR TITLE
Bos.Cmd.of_string: open the negative result ((_, [> R.msg ]) result)

### DIFF
--- a/src/bos.mli
+++ b/src/bos.mli
@@ -191,7 +191,7 @@ module Cmd : sig
 
   (** {1:convert Conversions and pretty printing} *)
 
-  val of_string : string -> (t, R.msg) result
+  val of_string : string -> (t, [> R.msg ]) result
   (** [of_string s] tokenizes [s] into a command line. The tokens
       are recognized according to the [token] production of the following
       grammar which should be mostly be compatible with POSIX shell


### PR DESCRIPTION
same as Pat.of_string etc. This makes programming and composition easier (avoids calls to Rresult.R.open_error_msg).