### PR TITLE
Fix is_directory check used in Bos.OS.Path.fold

### DIFF
--- a/src/bos_os_path.ml
+++ b/src/bos_os_path.ml
@@ -402,9 +402,15 @@ let is_element_fun err = function
 | `Dirs -> err_predicate_fun err dir_exists
 | `Sat sat -> err_predicate_fun err sat
 
+let is_directory p =
+  let stats = Unix.lstat p in
+  match stats.st_kind with
+  | Unix.S_DIR -> true
+  | _ -> false
+
 let is_dir_fun err =
-  let is_dir p = try Ok (Sys.is_directory (Fpath.to_string p)) with
-  | Sys_error e -> R.error_msg e
+  let is_dir p = try Ok (is_directory (Fpath.to_string p)) with
+  | Unix.Unix_error (e, _, _) -> R.error_msgf "%a: %s" Fpath.pp p (uerror e)  
   in
   err_predicate_fun err is_dir
 


### PR DESCRIPTION
[esy](https://github.com/esy/esy) uses `Bos.OS.Path.fold` as a helper to [copy files](https://github.com/esy/esy/blob/03966da4e3e3dd908d95820bf4b5c0d7b2b32009/esy-build-package/Run.re#L276)

Recently we face an issue https://github.com/mjambon/dune-deps/issues/23 
where esy goes into infinite loops while copying files, the reason for this is,

The project contained a symlink which points to its parent directory (https://github.com/mjambon/dune-deps/blob/master/test/proj/foo/link-to-parent)

The root cause for this infinite loop was `Sys.is_directory` returned `true` for the symlink which caused fold to traverse the parent directory repeatedly 

The fix for this is to use `Unix.lstat` to identify the kind of file
