### PR TITLE
fix OS.Dir.Create

### DIFF
--- a/src/bos_os_dir.ml
+++ b/src/bos_os_dir.ml
@@ -28,7 +28,7 @@ let create ?(path = true) ?(mode = 0o755) dir =
   | true -> Ok false
   | false ->
       match path with
-      | false -> mkdir dir mode >>= fun () -> Ok false
+      | false -> mkdir dir mode >>= fun () -> Ok true
       | true ->
           let rec dirs_to_create p acc = exists p >>= function
           | true -> Ok acc


### PR DESCRIPTION
Hi,

I believe this is the correct behavior according to the documentation:

> The result is false if dir already exists. 

I was getting `Ok false` even when the directory wasn't existing.

Also I've got a question: I'm getting `Ok true` when creating a directory named `d` if a file named `d` already exists... Is it expected ?