### PR TITLE
Use exception patterns in pattern matching instead of match try

### DIFF
--- a/src/bos_os_file.ml
+++ b/src/bos_os_file.ml
@@ -120,9 +120,9 @@ let read file =
 let fold_lines f acc file =
   let input ic acc =
     let rec loop acc =
-      match try Some (input_line ic) with End_of_file -> None with
-      | None -> acc
-      | Some line -> loop (f acc line)
+      match input_line ic with
+      | exception End_of_file -> acc
+      | line -> loop (f acc line)
     in
     loop acc
   in

--- a/src/bos_os_tmp.ml
+++ b/src/bos_os_tmp.ml
@@ -9,9 +9,9 @@ open Astring
 
 let default_dir_init =
   let from_env var ~absent =
-    match try Some (Sys.getenv var) with Not_found -> None with
-    | None -> absent
-    | Some v ->
+    match Sys.getenv var with
+    | exception Not_found -> absent
+    | v ->
         match Fpath.of_string v with
         | Error _ -> absent (* FIXME log something ? *)
         | Ok v -> v


### PR DESCRIPTION
They're nicer and also tail-recursive.

https://ocaml.org/manual/coreexamples.html#s%3Aexceptions
https://ocaml.org/manual/patterns.html#sss:exception-match