### PR TITLE
Bos_os_cmd: _find_tool: when a full path is provided, still check for existance

### DIFF
--- a/src/bos_os_cmd.ml
+++ b/src/bos_os_cmd.ml
@@ -129,7 +129,8 @@ let _find_tool ?search tool = match tool with
     match exe_is_path tool with
     | true ->
         begin match Fpath.of_string tool with
-        | Ok t -> Ok (Some t)
+        | Ok t when Bos_os_file.is_executable t -> Ok (Some t)
+        | Ok _ -> Ok None
         | Error (`Msg _) as e -> e
         end
     | false ->


### PR DESCRIPTION
Previously, Bos.OS.Cmd.must_exist (Bos.Cmd.v "/nonexisting/foo") always returned success. Now, it returns that that command is not found.