### PR TITLE
add Bos.OS.U.getwdg

### DIFF
--- a/src/bos_os_u.ml
+++ b/src/bos_os_u.ml
@@ -13,6 +13,8 @@ let rec call f v = try Ok (f v) with
 | Unix.Unix_error (Unix.EINTR, _, _) -> call f v
 | Unix.Unix_error (e, _, _) -> Error (`Unix e)
 
+let getcwd () = Fpath.of_string (Unix.getcwd ())
+
 let mkdir p m = try Ok (Unix.mkdir (Fpath.to_string p) m) with
 | Unix.Unix_error (e, _, _) -> Error (`Unix e)
 


### PR DESCRIPTION
Hi,

I'd like to get this function to be added to `Bos.OS.U` for convenience reasons.

I'm not sure what's the best between:

```ocaml
let getcwd () = Fpath.of_string (Unix.getcwd ())
```

Or trusting the Unix module to always return a meaningful path and do:

```ocaml
let getcwd () = Fpath.v (Unix.getcwd ())
```

What do you think?